### PR TITLE
[managed] Add IAccessor.Enabled property

### DIFF
--- a/Inc/IPC/Managed/detail/Accept.h
+++ b/Inc/IPC/Managed/detail/Accept.h
@@ -92,10 +92,10 @@ namespace Managed
 
 
         template <typename Request, typename Response>
-        auto Transport<Request, Response>::AcceptServers(System::String^ name, HandlerFactory^ handlerFactory, System::Boolean disabled)
+        auto Transport<Request, Response>::AcceptServers(System::String^ name, HandlerFactory^ handlerFactory, System::Boolean enabled)
             -> IServersAccessor^
         {
-            return gcnew ServersAccessor{ %m_transport, name, handlerFactory, !disabled };
+            return gcnew ServersAccessor{ %m_transport, name, handlerFactory, enabled };
         }
 
     } // detail

--- a/Inc/IPC/Managed/detail/Accept.h
+++ b/Inc/IPC/Managed/detail/Accept.h
@@ -6,10 +6,6 @@
 #include "ManagedCallback.h"
 #include "AccessorBase.h"
 
-#pragma managed(push, off)
-#include <boost/optional.hpp>
-#pragma managed(pop)
-
 #include <msclr/marshal.h>
 
 
@@ -20,19 +16,15 @@ namespace Managed
     namespace detail
     {
         template <typename Request, typename Response>
-        ref class Transport<Request, Response>::ServersAccessor : AccessorBase<IServer^>, IServersAccessor
+        ref class Transport<Request, Response>::ServersAccessor : AccessorBase<IServer^, NativeServersAccessor>, IServersAccessor
         {
         public:
-            ServersAccessor(NativeTransport& transport, System::String^ name, HandlerFactory^ handlerFactory)
-            try
-                : m_accessor{ transport.AcceptServers(
-                    msclr::interop::marshal_context().marshal_as<const char*>(name),
-                    MakeManagedCallback(gcnew ServerFactoryLambda{ handlerFactory, transport.GetConfig(), this }),
-                    MakeErrorHander(this)) }
-            {}
-            catch (const std::exception& /*e*/)
+            ServersAccessor(NativeObject<NativeTransport>^ transport, System::String^ name, HandlerFactory^ handlerFactory, System::Boolean enabled)
+                : m_transport{ transport },
+                  m_name{ name },
+                  m_handlerFactory{ handlerFactory }
             {
-                ThrowManagedException(std::current_exception());
+                Enabled = enabled;
             }
 
             property System::Collections::Generic::IReadOnlyCollection<IServer^>^ Servers
@@ -43,7 +35,7 @@ namespace Managed
 
                     try
                     {
-                        for (auto&& item : (*m_accessor)()())
+                        for (auto&& item : Accessor()())
                         {
                             auto holder = std::get_deleter<ComponentHolder<Server^>>(item);
                             assert(holder);
@@ -59,8 +51,19 @@ namespace Managed
                 }
             }
 
+        protected:
+            NativeServersAccessor MakeAccessor() override
+            {
+                auto& transport = **m_transport;
+
+                return transport.AcceptServers(
+                    msclr::interop::marshal_context().marshal_as<const char*>(m_name),
+                    MakeManagedCallback(gcnew ServerFactoryLambda{ m_handlerFactory, transport.GetConfig(), this }),
+                    MakeErrorHander(this));
+            }
+
         internal:
-            ref class ServerFactoryLambda : ComponentFactoryLambdaBase<NativeServer, NativeConfig, typename Transport::Server, IServer>
+            ref class ServerFactoryLambda : ComponentFactoryLambdaBase<NativeServer, NativeConfig, NativeServersAccessor, typename Transport::Server, IServer>
             {
             public:
                 ServerFactoryLambda(HandlerFactory^ handlerFactory, const NativeConfig& config, ServersAccessor^ accessor)
@@ -82,15 +85,17 @@ namespace Managed
             };
 
         private:
-            NativeObject<Interop::Callback<Interop::Callback<const NativeServerCollection&()>()>> m_accessor;
+            NativeObject<NativeTransport>^ m_transport;
+            System::String^ m_name;
+            HandlerFactory^ m_handlerFactory;
         };
 
 
         template <typename Request, typename Response>
-        auto Transport<Request, Response>::AcceptServers(System::String^ name, HandlerFactory^ handlerFactory)
+        auto Transport<Request, Response>::AcceptServers(System::String^ name, HandlerFactory^ handlerFactory, System::Boolean disabled)
             -> IServersAccessor^
         {
-            return gcnew ServersAccessor{ *m_transport, name, handlerFactory };
+            return gcnew ServersAccessor{ %m_transport, name, handlerFactory, !disabled };
         }
 
     } // detail

--- a/Inc/IPC/Managed/detail/AccessorBase.h
+++ b/Inc/IPC/Managed/detail/AccessorBase.h
@@ -36,16 +36,18 @@ namespace Managed
                 }
 
                 void set(System::Boolean value)
-                try
                 {
                     if (Enabled != value)
                     {
-                        *m_accessor = value ? boost::optional<NativeAccessor>{ MakeAccessor() } : boost::none;
+                        try
+                        {
+                            *m_accessor = value ? boost::optional<NativeAccessor>{ MakeAccessor() } : boost::none;
+                        }
+                        catch (const std::exception& /*e*/)
+                        {
+                            ThrowManagedException(std::current_exception());
+                        }
                     }
-                }
-                catch (const std::exception& /*e*/)
-                {
-                    ThrowManagedException(std::current_exception());
                 }
             }
 

--- a/Inc/IPC/Managed/detail/Connect.h
+++ b/Inc/IPC/Managed/detail/Connect.h
@@ -90,10 +90,10 @@ namespace Managed
 
         template <typename Request, typename Response>
         auto Transport<Request, Response>::ConnectClient(
-            System::String^ acceptorName, System::Boolean async, System::TimeSpan timeout, IClientConnector^ connector, System::Boolean disabled)
+            System::String^ acceptorName, System::Boolean async, System::TimeSpan timeout, IClientConnector^ connector, System::Boolean enabled)
             -> IClientAccessor^
         {
-            return gcnew ClientAccessor{ %m_transport, acceptorName, async, timeout, connector ? connector : m_clientConnector.Value, !disabled };
+            return gcnew ClientAccessor{ %m_transport, acceptorName, async, timeout, connector ? connector : m_clientConnector.Value, enabled };
         }
 
     } // detail

--- a/Inc/IPC/Managed/detail/Transport.h
+++ b/Inc/IPC/Managed/detail/Transport.h
@@ -41,7 +41,8 @@ namespace Managed
             using NativeClientConnector = typename NativeTransport::ClientConnector;
             using NativeServerAcceptor = typename NativeTransport::ServerAcceptor;
 
-            using NativeServerCollection = typename NativeTransport::ServerCollection;
+            using NativeClientAccessor = Interop::Callback<std::shared_ptr<void>()>;
+            using NativeServersAccessor = Interop::Callback<Interop::Callback<const typename NativeTransport::ServerCollection&()>()>;
 
         public:
             explicit Transport(Config^ config);
@@ -50,9 +51,10 @@ namespace Managed
 
             virtual IClientConnector^ MakeClientConnector();
 
-            virtual IClientAccessor^ ConnectClient(System::String^ acceptorName, System::Boolean async, System::TimeSpan timeout, IClientConnector^ connector);
+            virtual IClientAccessor^ ConnectClient(
+                System::String^ acceptorName, System::Boolean async, System::TimeSpan timeout, IClientConnector^ connector, System::Boolean disabled);
 
-            virtual IServersAccessor^ AcceptServers(System::String^ name, HandlerFactory^ handlerFactory);
+            virtual IServersAccessor^ AcceptServers(System::String^ name, HandlerFactory^ handlerFactory, System::Boolean disabled);
 
         internal:
             ref class Server;

--- a/Inc/IPC/Managed/detail/Transport.h
+++ b/Inc/IPC/Managed/detail/Transport.h
@@ -52,9 +52,9 @@ namespace Managed
             virtual IClientConnector^ MakeClientConnector();
 
             virtual IClientAccessor^ ConnectClient(
-                System::String^ acceptorName, System::Boolean async, System::TimeSpan timeout, IClientConnector^ connector, System::Boolean disabled);
+                System::String^ acceptorName, System::Boolean async, System::TimeSpan timeout, IClientConnector^ connector, System::Boolean enabled);
 
-            virtual IServersAccessor^ AcceptServers(System::String^ name, HandlerFactory^ handlerFactory, System::Boolean disabled);
+            virtual IServersAccessor^ AcceptServers(System::String^ name, HandlerFactory^ handlerFactory, System::Boolean enabled);
 
         internal:
             ref class Server;

--- a/Transport/IAccessor.cs
+++ b/Transport/IAccessor.cs
@@ -8,5 +8,7 @@ namespace IPC.Managed
         event EventHandler<ComponentEventArgs<T>> Connected;
 
         event EventHandler<ComponentEventArgs<T>> Disconnected;
+
+        bool Enabled { get; set; }
     }
 }

--- a/Transport/ITransport.cs
+++ b/Transport/ITransport.cs
@@ -15,8 +15,8 @@ namespace IPC.Managed
         IClientConnector<Request, Response> MakeClientConnector();
 
         IClientAccessor<Request, Response> ConnectClient(
-            string name, bool async, TimeSpan timeout = default(TimeSpan), IClientConnector<Request, Response> connector = null);
+            string name, bool async, TimeSpan timeout = default(TimeSpan), IClientConnector<Request, Response> connector = null, bool disabled = false);
 
-        IServersAccessor<Request, Response> AcceptServers(string name, HandlerFactory<Request, Response> handlerFactory);
+        IServersAccessor<Request, Response> AcceptServers(string name, HandlerFactory<Request, Response> handlerFactory, bool disabled = false);
     }
 }

--- a/Transport/ITransport.cs
+++ b/Transport/ITransport.cs
@@ -15,8 +15,8 @@ namespace IPC.Managed
         IClientConnector<Request, Response> MakeClientConnector();
 
         IClientAccessor<Request, Response> ConnectClient(
-            string name, bool async, TimeSpan timeout = default(TimeSpan), IClientConnector<Request, Response> connector = null, bool disabled = false);
+            string name, bool async, TimeSpan timeout = default(TimeSpan), IClientConnector<Request, Response> connector = null, bool enabled = true);
 
-        IServersAccessor<Request, Response> AcceptServers(string name, HandlerFactory<Request, Response> handlerFactory, bool disabled = false);
+        IServersAccessor<Request, Response> AcceptServers(string name, HandlerFactory<Request, Response> handlerFactory, bool enabled = true);
     }
 }


### PR DESCRIPTION
Currently there is no way to receive notifications for `IAccessor.Connected`, `IAccessor.Disconnected` and `IAccessor.Error` events that happen between object construction and event subscription. Adding `IAccessor.Enabled` property which will allow construction in disabled mode, so that none of the events will be missed.