### PR TITLE
[native] Fix std::chrono::duration default initialization

### DIFF
--- a/Inc/IPC/Policies/InfiniteTimeoutFactory.h
+++ b/Inc/IPC/Policies/InfiniteTimeoutFactory.h
@@ -12,7 +12,7 @@ namespace Policies
     class InfiniteTimeoutFactory
     {
     public:
-        InfiniteTimeoutFactory(const std::chrono::milliseconds& /*defaultTimeout*/ = {})
+        InfiniteTimeoutFactory(const std::chrono::milliseconds& /*defaultTimeout*/ = std::chrono::milliseconds::zero())
         {}
 
         auto operator()(const detail::Callback<void()>& /*handler*/) const

--- a/Inc/IPC/Policies/TimeoutFactory.h
+++ b/Inc/IPC/Policies/TimeoutFactory.h
@@ -42,7 +42,7 @@ namespace Policies
         };
 
     public:
-        TimeoutFactory(const std::chrono::milliseconds& defaultTimeout = {}, boost::optional<ThreadPool> pool = {});
+        TimeoutFactory(const std::chrono::milliseconds& defaultTimeout = std::chrono::milliseconds::zero(), boost::optional<ThreadPool> pool = {});
 
         Scheduler operator()(detail::Callback<void()> handler) const;
 

--- a/Inc/IPC/Policies/TransactionManager.h
+++ b/Inc/IPC/Policies/TransactionManager.h
@@ -23,13 +23,13 @@ namespace Policies
 
         TransactionManager() = default;
 
-        explicit TransactionManager(TimeoutFactory timeoutFactory, const std::chrono::milliseconds& defaultTimeout = {})
+        explicit TransactionManager(TimeoutFactory timeoutFactory, const std::chrono::milliseconds& defaultTimeout = std::chrono::milliseconds::zero())
             : m_timeoutFactory{ std::move(timeoutFactory) },
               m_defaultTimeout{ NonZeroTimeout(defaultTimeout) }
         {}
 
         template <typename OtherContext>
-        Id BeginTransaction(OtherContext&& context, const std::chrono::milliseconds& timeout = {})
+        Id BeginTransaction(OtherContext&& context, const std::chrono::milliseconds& timeout = std::chrono::milliseconds::zero())
         {
             auto result = m_transactions->Take(
                 [this](Id id)

--- a/UnitTests/TimeoutFactoryMock.h
+++ b/UnitTests/TimeoutFactoryMock.h
@@ -33,7 +33,7 @@ namespace Mocks
         };
 
     public:
-        TimeoutFactory(const std::chrono::milliseconds& defaultTimeout = {});
+        TimeoutFactory(const std::chrono::milliseconds& defaultTimeout = std::chrono::milliseconds::zero());
 
         std::size_t Process();
 


### PR DESCRIPTION
Resolves #22.